### PR TITLE
add license headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>2.13.0</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>2.13.0</version>
+      <type>pom</type>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>2.13.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <name>CML Euclid</name>
   <description>A Java library for 2D and 3D geometric calculations</description>
   <url>https://github.com/BlueObelisk/euclid</url>
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -27,11 +28,13 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <scm>
     <url>https://github.com/BlueObelisk/euclid</url>
     <connection>scm:git:https://github.com/BlueObelisk/euclid</connection>
     <developerConnection>scm:git:https://github.com/BlueObelisk/euclid</developerConnection>
   </scm>
+
   <developers>
     <developer>
       <id>pm286</id>
@@ -168,6 +171,11 @@
       <artifactId>log4j</artifactId>
       <version>2.13.0</version>
       <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.13.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/xmlcml/euclid/Bivariate.java
+++ b/src/main/java/org/xmlcml/euclid/Bivariate.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import org.apache.log4j.Logger;

--- a/src/main/java/org/xmlcml/euclid/IntRangeArray.java
+++ b/src/main/java/org/xmlcml/euclid/IntRangeArray.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.io.PrintStream;

--- a/src/main/java/org/xmlcml/euclid/Line2AndReal2Calculator.java
+++ b/src/main/java/org/xmlcml/euclid/Line2AndReal2Calculator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 public class Line2AndReal2Calculator {

--- a/src/main/java/org/xmlcml/euclid/ParsedSymop.java
+++ b/src/main/java/org/xmlcml/euclid/ParsedSymop.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.regex.Matcher;

--- a/src/main/java/org/xmlcml/euclid/Real2RangeComparator.java
+++ b/src/main/java/org/xmlcml/euclid/Real2RangeComparator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.Comparator;

--- a/src/main/java/org/xmlcml/euclid/RealComparator.java
+++ b/src/main/java/org/xmlcml/euclid/RealComparator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.Comparator;

--- a/src/main/java/org/xmlcml/euclid/RealRangeArray.java
+++ b/src/main/java/org/xmlcml/euclid/RealRangeArray.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.io.PrintStream;

--- a/src/main/java/org/xmlcml/euclid/RealRangeComparator.java
+++ b/src/main/java/org/xmlcml/euclid/RealRangeComparator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.Comparator;

--- a/src/main/java/org/xmlcml/euclid/RealRangeList.java
+++ b/src/main/java/org/xmlcml/euclid/RealRangeList.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.ArrayList;

--- a/src/main/java/org/xmlcml/euclid/StringComparator.java
+++ b/src/main/java/org/xmlcml/euclid/StringComparator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 import java.util.Comparator;

--- a/src/main/java/org/xmlcml/euclid/UnivariateBin.java
+++ b/src/main/java/org/xmlcml/euclid/UnivariateBin.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid;
 
 /** manages the contents of a Bin in Univariate as a sub-Univariate

--- a/src/main/java/org/xmlcml/euclid/test/DoubleTestBase.java
+++ b/src/main/java/org/xmlcml/euclid/test/DoubleTestBase.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust, Nick England, David Jessop
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.euclid.test;
 
 import org.junit.Assert;

--- a/src/main/java/org/xmlcml/euclid/test/EuclidTestBase.java
+++ b/src/main/java/org/xmlcml/euclid/test/EuclidTestBase.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust, Nick England, David Jessop
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.euclid.test;
 
 

--- a/src/main/java/org/xmlcml/euclid/test/StringTestBase.java
+++ b/src/main/java/org/xmlcml/euclid/test/StringTestBase.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust, Nick England, David Jessop
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.euclid.test;
 
 import org.junit.Assert;

--- a/src/main/java/org/xmlcml/euclid/util/MultisetUtil.java
+++ b/src/main/java/org/xmlcml/euclid/util/MultisetUtil.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.util;
 
 import java.util.ArrayList;

--- a/src/main/java/org/xmlcml/stml/AbstractSTMTool.java
+++ b/src/main/java/org/xmlcml/stml/AbstractSTMTool.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import org.xmlcml.xml.XMLConstants;

--- a/src/main/java/org/xmlcml/stml/STMLArray.java
+++ b/src/main/java/org/xmlcml/stml/STMLArray.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import java.text.ParseException;

--- a/src/main/java/org/xmlcml/stml/STMLAttribute.java
+++ b/src/main/java/org/xmlcml/stml/STMLAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/STMLConstants.java
+++ b/src/main/java/org/xmlcml/stml/STMLConstants.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import nu.xom.XPathContext;

--- a/src/main/java/org/xmlcml/stml/STMLElement.java
+++ b/src/main/java/org/xmlcml/stml/STMLElement.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import java.io.File;

--- a/src/main/java/org/xmlcml/stml/STMLScalar.java
+++ b/src/main/java/org/xmlcml/stml/STMLScalar.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import java.text.ParseException;

--- a/src/main/java/org/xmlcml/stml/STMLType.java
+++ b/src/main/java/org/xmlcml/stml/STMLType.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml;
 
 import java.text.NumberFormat;

--- a/src/main/java/org/xmlcml/stml/attribute/AttributeFactory.java
+++ b/src/main/java/org/xmlcml/stml/attribute/AttributeFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 /**
  * 
  */

--- a/src/main/java/org/xmlcml/stml/attribute/DelimiterAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/DelimiterAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/DictRefAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/DictRefAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/DoubleArraySTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/DoubleArraySTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import java.text.ParseException;

--- a/src/main/java/org/xmlcml/stml/attribute/DoubleSTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/DoubleSTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import java.text.ParseException;

--- a/src/main/java/org/xmlcml/stml/attribute/IdAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/IdAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/IntArraySTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/IntArraySTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/IntSTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/IntSTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import org.xmlcml.stml.STMLAttribute;

--- a/src/main/java/org/xmlcml/stml/attribute/NamespaceRefAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/NamespaceRefAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/StringArraySTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/StringArraySTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/attribute/StringSTAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/StringSTAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import org.xmlcml.stml.STMLAttribute;

--- a/src/main/java/org/xmlcml/stml/attribute/UnitsAttribute.java
+++ b/src/main/java/org/xmlcml/stml/attribute/UnitsAttribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.attribute;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/interfacex/HasArraySize.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasArraySize.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 import java.util.List;

--- a/src/main/java/org/xmlcml/stml/interfacex/HasDataType.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasDataType.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 /**

--- a/src/main/java/org/xmlcml/stml/interfacex/HasDelimiter.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasDelimiter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/stml/interfacex/HasDictRef.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasDictRef.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 import org.xmlcml.stml.STMLAttribute;

--- a/src/main/java/org/xmlcml/stml/interfacex/HasScalar.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasScalar.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 

--- a/src/main/java/org/xmlcml/stml/interfacex/HasUnits.java
+++ b/src/main/java/org/xmlcml/stml/interfacex/HasUnits.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.stml.interfacex;
 
 

--- a/src/main/java/org/xmlcml/testutil/TestUtils.java
+++ b/src/main/java/org/xmlcml/testutil/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.testutil;
 
 import java.io.File;

--- a/src/main/java/org/xmlcml/xml/XMLConstants.java
+++ b/src/main/java/org/xmlcml/xml/XMLConstants.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.xml;
 
 import nu.xom.XPathContext;

--- a/src/main/java/org/xmlcml/xml/XMLUtil.java
+++ b/src/main/java/org/xmlcml/xml/XMLUtil.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2011 Peter Murray-Rust et. al.
+ *    Copyright 2011 Peter Murray-Rust
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.xmlcml.xml;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/org/xmlcml/xml/XPathGenerator.java
+++ b/src/main/java/org/xmlcml/xml/XPathGenerator.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.xml;
 
 import org.apache.log4j.Level;

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-#    Copyright 2011 Peter Murray-Rust et. al.
+#    Copyright 2011 Peter Murray-Rust
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/src/test/java/org/xmlcml/Fixtures.java
+++ b/src/test/java/org/xmlcml/Fixtures.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml;
 
 import java.io.File;

--- a/src/test/java/org/xmlcml/euclid/test/BivariateTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/BivariateTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import junit.framework.Assert;

--- a/src/test/java/org/xmlcml/euclid/test/IntRangeArrayTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/IntRangeArrayTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import junit.framework.Assert;

--- a/src/test/java/org/xmlcml/euclid/test/ParsedSymopTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/ParsedSymopTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import junit.framework.Assert;

--- a/src/test/java/org/xmlcml/euclid/test/Real2RangeComparatorTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/Real2RangeComparatorTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import java.util.Set;

--- a/src/test/java/org/xmlcml/euclid/test/RealComparatorTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/RealComparatorTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import java.util.HashSet;

--- a/src/test/java/org/xmlcml/euclid/test/RealRangeArrayTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/RealRangeArrayTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import java.util.ArrayList;

--- a/src/test/java/org/xmlcml/euclid/test/RealRangeComparatorTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/RealRangeComparatorTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import java.util.Set;

--- a/src/test/java/org/xmlcml/euclid/test/RealRangeListTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/RealRangeListTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import org.apache.log4j.Logger;

--- a/src/test/java/org/xmlcml/euclid/test/StringArrayTest.java
+++ b/src/test/java/org/xmlcml/euclid/test/StringArrayTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.test;
 
 import java.util.Arrays;

--- a/src/test/java/org/xmlcml/euclid/testutil/Real2TestUtil.java
+++ b/src/test/java/org/xmlcml/euclid/testutil/Real2TestUtil.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.euclid.testutil;
 
 import static org.xmlcml.euclid.EuclidConstants.S_RBRAK;

--- a/src/test/java/org/xmlcml/xml/XMLUtilTest.java
+++ b/src/test/java/org/xmlcml/xml/XMLUtilTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2011 Peter Murray-Rust
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.xmlcml.xml;
 
 import nu.xom.Element;


### PR DESCRIPTION
adding the Apache-2.0 license header that lives in `src/main/resources/header.txt` to almost all text-files.

```
   Copyright 2011 Peter Murray-Rust

   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

       http://www.apache.org/licenses/LICENSE-2.0

   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
```
